### PR TITLE
Fix: fallback logic for stream variants

### DIFF
--- a/chaturbate/chaturbate.go
+++ b/chaturbate/chaturbate.go
@@ -144,7 +144,7 @@ func PickPlaylist(masterPlaylist *m3u8.MasterPlaylist, baseURL string, resolutio
 			return nil, fmt.Errorf("parse resolution: %w", err)
 		}
 		framerateVal := 30
-		if strings.Contains(v.Name, "FPS:60.0") {
+		if strings.Contains(v.Name, "FPS:60.0") && framerate == 60 {
 			framerateVal = 60
 		}
 		if _, exists := resolutions[width]; !exists {


### PR DESCRIPTION
## Problem
If available, 60 FPS is used regardless of config option.