### PR TITLE
Handle multiple input better

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func start(c *cli.Context) error {
 		Pattern:     c.String("pattern"),
 		MaxDuration: c.Int("max-duration"),
 		MaxFilesize: c.Int("max-filesize"),
-	}, false); err != nil {
+	}, false, 0); err != nil {
 		return fmt.Errorf("create channel: %w", err)
 	}
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -87,7 +87,7 @@ func (m *Manager) LoadConfig() error {
 }
 
 // CreateChannel starts monitoring an M3U8 stream
-func (m *Manager) CreateChannel(conf *entity.ChannelConfig, shouldSave bool) error {
+func (m *Manager) CreateChannel(conf *entity.ChannelConfig, shouldSave bool, seq int) error {
 	conf.Sanitize()
 	ch := channel.New(conf)
 
@@ -98,7 +98,7 @@ func (m *Manager) CreateChannel(conf *entity.ChannelConfig, shouldSave bool) err
 	}
 	m.Channels.Store(conf.Username, ch)
 
-	go ch.Resume(0)
+	go ch.Resume(seq)
 
 	if shouldSave {
 		if err := m.SaveConfig(); err != nil {

--- a/router/router_handler.go
+++ b/router/router_handler.go
@@ -43,7 +43,7 @@ func CreateChannel(c *gin.Context) {
 		return
 	}
 
-	for _, username := range strings.Split(req.Username, ",") {
+	for i, username := range strings.Split(req.Username, ",") {
 		server.Manager.CreateChannel(&entity.ChannelConfig{
 			IsPaused:    false,
 			Username:    username,
@@ -53,7 +53,7 @@ func CreateChannel(c *gin.Context) {
 			MaxDuration: req.MaxDuration,
 			MaxFilesize: req.MaxFilesize,
 			CreatedAt:   time.Now().Unix(),
-		}, true)
+		}, true, i)
 	}
 	c.Redirect(http.StatusFound, "/")
 }

--- a/server/manager.go
+++ b/server/manager.go
@@ -9,7 +9,7 @@ import (
 var Manager IManager
 
 type IManager interface {
-	CreateChannel(conf *entity.ChannelConfig, shouldSave bool) error
+	CreateChannel(conf *entity.ChannelConfig, shouldSave bool, seq int) error
 	StopChannel(username string) error
 	PauseChannel(username string) error
 	ResumeChannel(username string) error


### PR DESCRIPTION
Fix for handling addition of multiple channels better.

If the user is adding a larger amount of channels, they will all process at the same time, creating unwanted lag/bottleneck.

Using same methodology as ch.Resume(<seq>) 